### PR TITLE
Added internal app Firebase build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'timehop/nimbus-android'
+          ssh-key: ${{ secrets.NIMBUS_ANDROID_KEY }}
           lfs: true
 
       - name: Checkout Sample code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,48 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Run Gradle Build
-        run: ./gradlew build check --no-daemon --stacktrace
+        run: ./gradlew build check --stacktrace
+
+  next-build:
+    name: Internal App Build
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Internal code
+        uses: actions/checkout@v3
+        with:
+          repository: 'timehop/nimbus-android'
+          lfs: true
+
+      - name: Checkout Sample code
+        uses: actions/checkout@v3
+        with:
+          path: 'shared'
+          lfs: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ./.gradle/configuration-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+            ${{ runner.os }}-gradle-
+
+      - name: Setup Firebase Key
+        run: echo ${{ secrets.FIREBASE_SERVICE_KEY_JSON }} | base64 --decode > ./firebase.json
+
+      - name: Build and Deploy to Firebase
+        env:
+          ORG_GRADLE_PROJECT_firebaseAppId: ${{ secrets.FIREBASE_APP_ID }}
+          ORG_GRADLE_PROJECT_releaseDescription: ${{ github.event.pull_request.body || github.event.head_commit.message }}
+        run: ./gradlew appDistributionUploadDebug --stacktrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Setup Firebase Key
-        run: echo ${{ secrets.FIREBASE_SERVICE_KEY_JSON }} | base64 --decode > ./firebase.json
+        run: echo ${{ secrets.FIREBASE_DEPLOY_JSON }} | base64 --decode > ./firebase.json
 
       - name: Build and Deploy to Firebase
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,4 +89,4 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_firebaseAppId: ${{ secrets.FIREBASE_APP_ID }}
           ORG_GRADLE_PROJECT_releaseDescription: ${{ github.event.pull_request.body || github.event.head_commit.message }}
-        run: ./gradlew appDistributionUploadDebug --stacktrace
+        run: ./gradlew :app:build appDistributionUploadDebug --stacktrace


### PR DESCRIPTION
This PR adds an additional job as part of the validation build that will checkout the latest commit of the SDK and run the internal app build in parallel to the sample app build to validate that there were no breaking changes commited that have not been properly deprecated with at least 1 release.