### PR TITLE
Fixed gradle property overrides

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,21 +29,21 @@ sample_api_key=d352cac1-cae2-4774-97ba-4e15c6276be0
 
 # Aps Demand Slot IDs
 sample_aps_app_key=a9_onboarding_app_id
-sample_aps_banner=
-sample_aps_static=
-sample_aps_video=
+#sample_aps_banner=
+#sample_aps_static=
+#sample_aps_video=
 
 # Facebook Audience Network Ad Unit IDs
 # These are not required by Nimbus but enabled rendering of sample Facebook ads
-sample_fan_native=
-sample_fan_native_320=
-sample_fan_banner_320=
-sample_fan_interstitial=
-sample_fan_rewarded_video=
+#sample_fan_native_id=
+#sample_fan_native_320_id=
+#sample_fan_banner_320_id=
+#sample_fan_interstitial_id=
+#sample_fan_rewarded_video_id=
 
 # Google Ad Manager Ad Unit IDs
-sample_gam_placement_id=
-sample_gam_interstitial_id=
+#sample_gam_placement_id=
+#sample_gam_interstitial_id=
 
 # Unity Demand
-sample_unity_game_id=
+#sample_unity_game_id=

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     implementation("com.adsbynimbus.android:extension-unity:$nimbusVersion")
 
     // Aps
-    implementation("com.amazon.android:aps-sdk:9.4.2")
+    implementation("com.amazon.android:aps-sdk:9.4.3")
 
     // Facebook
     implementation("com.facebook.android:audience-network-sdk:6.8.0")
@@ -85,9 +85,9 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.4.1")
 
     // Navigation
-    implementation("androidx.navigation:navigation-fragment-ktx:2.4.1")
-    implementation("androidx.navigation:navigation-runtime-ktx:2.4.1")
-    implementation("androidx.navigation:navigation-ui-ktx:2.4.1")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.4.2")
+    implementation("androidx.navigation:navigation-runtime-ktx:2.4.2")
+    implementation("androidx.navigation:navigation-ui-ktx:2.4.2")
 
     // Preferences
     implementation("androidx.preference:preference-ktx:1.2.0")

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,7 +1,16 @@
+import com.android.build.api.dsl.LibraryDefaultConfig
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.toUpperCaseAsciiOnly
+
 plugins {
     id("com.android.library")
     kotlin("android")
     id("androidx.navigation.safeargs") version("2.4.1")
+}
+
+// Demonstrates the usage of extension functions and gradle providers to add a buildConfigField
+fun LibraryDefaultConfig.addSampleBuildConfigField(name: String) {
+    buildConfigField("String", name.substringAfter("_").toUpperCaseAsciiOnly(),
+        "\"${providers.gradleProperty(name).getOrElse("")}\"")
 }
 
 android {
@@ -15,18 +24,21 @@ android {
         minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // This is one example of adding keys to the application using buildConfigField
         buildConfigField("String", "PUBLISHER_KEY", "\"${property("sample_publisher_key")}\"")
         buildConfigField("String", "API_KEY", "\"${property("sample_api_key")}\"")
-        buildConfigField("String", "APS_APP_KEY", "\"${property("sample_aps_app_key")}\"")
-        buildConfigField("String", "APS_BANNER", "\"${property("sample_aps_banner")}\"")
-        buildConfigField("String", "APS_STATIC", "\"${property("sample_aps_static")}\"")
-        buildConfigField("String", "APS_VIDEO", "\"${property("sample_aps_video")}\"")
-        buildConfigField("String", "FAN_NATIVE_ID", "\"${property("sample_fan_native")}\"")
-        buildConfigField("String", "FAN_INTERSTITIAL_ID", "\"${property("sample_fan_interstitial")}\"")
-        buildConfigField("String", "FAN_BANNER_320_ID", "\"${property("sample_fan_banner_320")}\"")
-        buildConfigField("String", "FAN_NATIVE_320_ID", "\"${property("sample_fan_native_320")}\"")
-        buildConfigField("String", "GAM_PLACEMENT_ID", "\"${property("sample_gam_placement_id")}\"")
-        buildConfigField("String", "UNITY_GAME_ID", "\"${property("sample_unity_game_id")}\"")
+
+        // The following uses buildConfigField and gradle property providers to add keys
+        addSampleBuildConfigField("sample_aps_app_key")
+        addSampleBuildConfigField("sample_aps_banner")
+        addSampleBuildConfigField("sample_aps_static")
+        addSampleBuildConfigField("sample_aps_video")
+        addSampleBuildConfigField("sample_fan_native_id")
+        addSampleBuildConfigField("sample_fan_interstitial_id")
+        addSampleBuildConfigField("sample_fan_banner_320_id")
+        addSampleBuildConfigField("sample_fan_native_320_id")
+        addSampleBuildConfigField("sample_gam_placement_id")
+        addSampleBuildConfigField("sample_unity_game_id")
     }
 
     compileOptions {


### PR DESCRIPTION
This PR comments out the definition of the sample app gradle properties so they can be overriden by the build or by another project.

Additionally updated Androidx Navigation to 2.4.2 and APS to 9.4.3