### PR TITLE
Updated Nimbus to 2.4.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("nimbus.app")
 }
 
-val nimbusVersion = "2.3.0"
+val nimbusVersion = "2.4.0"
 
 /* The compileSdk, minSdk, and targetSdk are applied in the build-logic/src/main/kotlin/nimbus.app.gradle.kts plugin */
 android {
@@ -56,7 +56,6 @@ dependencies {
     api("com.adsbynimbus.android:extension-aps:$nimbusVersion")
     api("com.adsbynimbus.android:extension-facebook:$nimbusVersion")
     api("com.adsbynimbus.android:extension-google:$nimbusVersion")
-    api("com.adsbynimbus.android:extension-viewability:$nimbusVersion")
     api("com.adsbynimbus.android:extension-unity:$nimbusVersion")
 
     api("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/app/src/main/java/com/adsbynimbus/android/sample/Settings.kt
+++ b/app/src/main/java/com/adsbynimbus/android/sample/Settings.kt
@@ -4,7 +4,6 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import com.adsbynimbus.Nimbus
-import com.adsbynimbus.ViewabilityProvider
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
@@ -35,7 +34,7 @@ fun SharedPreferences.initNimbusFeatures(features: Set<String> = all.keys) {
                 }.apply()
             }
             "ccpa_consent" -> Nimbus.usPrivacyString = "1NYN".takeIf { _ -> getBoolean(it, false) }
-            "enable_viewability" -> ViewabilityProvider.thirdPartyViewabilityEnabled = getBoolean(it, true)
+            "enable_viewability" -> Nimbus.thirdPartyViewabilityEnabled = getBoolean(it, true)
             "enabled_gpp" -> getBoolean(it, false).let { testEnabled ->
                 edit().apply {
                     if (testEnabled) putString("IABGPP_HDR_GppString",

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -41,7 +41,7 @@
         android:selectable="false"
         app:allowDividerAbove="true"
         app:allowDividerBelow="true"
-        app:defaultValue="false"
+        app:defaultValue="true"
         app:switchWidgetContentDescription="enableViewabilityPreferenceSwitch"
         app:key="enable_viewability"
         app:title="@string/settings_enable_viewability"


### PR DESCRIPTION
## Changes

- Removed extension-viewability module as it's code is now included with `com.adsbynimbus.android:nimbus:2.4.0`
- Replaced usage of `ViewabilityProvider.thirdPartyViewabilityEnabled` with `Nimbus.thirdPartyViewabilityEnabled`
- `Send OMID Viewability Flag` setting now defaults to true to match the initial Nimbus state