### PR TITLE
Added play.core.hsdp library to the overrideLibrary List

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!--  overrides minSdk set by moloco sdk and admob to allow us to build with minSdk 21. -->
-    <uses-sdk tools:overrideLibrary="com.moloco.sdk,com.moloco.sdk.acm,com.moloco.sdk.protobuf,com.adsbynimbus.moloco,androidx.browser,com.google.android.libraries.ads.mobile.sdk,com.google.android.ads.consent,com.google.android.gms.common,androidx.webkit,org.chromium.net.cronet_fallback,org.chromium.net.httpengine_native_provider,org.chromium.net.cronet_common,org.chromium.net.cronet_api,org.chromium.net.cronet_shared,com.adsbynimbus.admobnextgen"/>
+    <uses-sdk  android:minSdkVersion="21"
+        tools:overrideLibrary="com.google.android.play.core.hsdp,com.moloco.sdk,com.moloco.sdk.acm,com.moloco.sdk.protobuf,com.adsbynimbus.moloco,androidx.browser,com.google.android.libraries.ads.mobile.sdk,com.google.android.ads.consent,com.google.android.gms.common,androidx.webkit,org.chromium.net.cronet_fallback,org.chromium.net.httpengine_native_provider,org.chromium.net.cronet_common,org.chromium.net.cronet_api,org.chromium.net.cronet_shared,com.adsbynimbus.admobnextgen"/>
 
     <application
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
# Story/Task:
- No story

# Changes
- "com.google.android.play.core.hsdp" from "admobnextgen" dependency requires min sdk 23 in order to get the app to compile, added another exception to the overrideLibrary list so force sdk 21 support.